### PR TITLE
fix usage info for option --caller

### DIFF
--- a/tb-profiler
+++ b/tb-profiler
@@ -242,7 +242,7 @@ if __name__=="__main__":
 	parser_sub.add_argument('--prefix','-p',default="tbprofiler",help='Sample prefix for all results generated')
 	parser_sub.add_argument('--db',default='tbdb',help='Mutation panel name')
 	parser_sub.add_argument('--mapper',default="bwa", choices=["bwa","minimap2","bowtie2"],help="Mapping tool to use. If you are using minION data it will default to minimap2",type=str)
-	parser_sub.add_argument('--caller',default="GATK", choices=["BCFtools","GATK"],help="Variant calling tool to use. Currently only BCFtools supported",type=str)
+	parser_sub.add_argument('--caller',default="GATK", choices=["BCFtools","GATK"],help="Variant calling tool to use.",type=str)
 	parser_sub.add_argument('--min_depth',default=10,type=int,help='Minimum depth required to call variant. Bases with depth below this cutoff will be marked as missing')
 	parser_sub.add_argument('--af',default=0.1,type=float,help='Minimum allele frequency to call variants')
 	parser_sub.add_argument('--reporting_af',default=0.1,type=float,help='Minimum allele frequency to call variants')


### PR DESCRIPTION
remove `Currently only BCFtools supported` from usage of `--caller`