### PR TITLE
313 fix create db and load library

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ If you would like to use an altered database you can download the tbdb repo, mak
 
 ```text
 tb-profiler create_db --prefix <new_library_name>
-tb-profiler load_library --prefix <new_library_name>
+tb-profiler load_library <new_library_name>
 ```
 
 ### Non-H37Rv databases

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
 	long_description="TBProfiler command line tool",
 	scripts= [
 		'tb-profiler',
-        'scripts/tb-profiler-tools'
+		'scripts/tb-profiler-tools'
 		],
 	data_files=[('share/tbprofiler',["db/default_template.docx","db/tbdb.mask.bed","db/tbdb.spoligotype_spacers.txt","db/tbdb.spoligotype_list.csv","db/tbdb.barcode.bed","db/tbdb.bed","db/tbdb.dr.json","db/tbdb.fasta","db/tbdb.gff","db/tbdb.version.json","db/tbdb.variables.json","example_data/tbprofiler.test.fq.gz"])]
 )

--- a/tb-profiler
+++ b/tb-profiler
@@ -206,7 +206,7 @@ def main_create_db(args):
 
 def main_load_library(args):
     variables_file = "%(prefix)s.variables.json" % vars(args)
-    source_dir = "/".join(variables_file.split("/")[:-1])
+    source_dir = os.path.realpath(args.dir)
     pp.load_db(variables_file,args.software_name,source_dir=source_dir)
     
 


### PR DESCRIPTION
This PR is in connection with issue #313. Really just a hotfix that does the following:
* `os.path.realpath` used to get the full path for the `source_dir`.
* Updated the README regarding how to generate and load user-specified databases.
* Fixed `setup.py` indentation error. 