### PR TITLE
Fix link to new TGV

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ tb-profiler collate
 
 This will automatically create a number of colled result files from all the individual result files in the _result_ directory. If you would like to generate this file for a subset of the runs you can provide a list with the run sames using the `--samples` flag. The prefix for the output files is _tbprofiler_ by default but this can be changed with the `--prefix` flag.
 
-If `tb-profiler` has been run using the `--snp_dist` argument, the `collate` function will also generate a transmission graph in json format that can be visualised by dragging and dropping the file into [this site](https://jodyphelan.github.io/transmission-graph-viewer)
+If `tb-profiler` has been run using the `--snp_dist` argument, the `collate` function will also generate a transmission graph in json format that can be visualised by dragging and dropping the file into [this site](https://jodyphelan.github.io/tgv/)
 
 ### Writing your own summary scripts
 


### PR DESCRIPTION
The old link in the `collate` section linked to the old TGV page which now simply redirects to the new https://jodyphelan.github.io/tgv/