### PR TITLE
Clean up code, detect if there are not results to collate

### DIFF
--- a/tb-profiler
+++ b/tb-profiler
@@ -271,8 +271,8 @@ def main_create_db(args):
         dbs = pp.list_db(args.software_name)
         names = [x['version']['name'] for x in dbs]
         if args.prefix in names:
-            pp.warninglog("\nWarning: A database with this name already exists!\n")
-            sys.exit()
+            logging.error("\nERROR: A database with this name already exists!\n")
+            sys.exit(1)
 
     extra_files = {
         "spoligotype_spacers": args.spoligotypes,
@@ -304,8 +304,8 @@ def main_load_library(args):
 
             variables_files = glob.glob(f"{tmpfolder}/*.variables.json")
             if len(variables_files)!=1:
-                pp.errorlog("Archive must contain only one variables file")
-                sys.exit()
+                logging.error("\nERROR: Archive must contain only one variables file")
+                sys.exit(1)
             variables_file = variables_files[0]
             args.prefix = "{}/{}".format(tmpfolder,variables_file.split("/")[-1].replace(".variables.json",""))
             source_dir = os.path.realpath(tmpfolder)

--- a/tbprofiler/__init__.py
+++ b/tbprofiler/__init__.py
@@ -9,4 +9,4 @@ from .docx import *
 from .plugins import *
 from .rules import *
 
-__version__ = "6.6.5"
+__version__ = "6.6.6"

--- a/tbprofiler/collate.py
+++ b/tbprofiler/collate.py
@@ -85,14 +85,21 @@ def collate_results(args: argparse.Namespace) -> None:
     drugs = args.conf['drugs']
 
     samples = {}
+    sample_suffix = '.results.json'
     for d in args.dir:
         for f in os.listdir(f"{d}/"):
-            if f.endswith(".results.json"):
-                s = f.replace(".results.json","")
-                samples[s] = f'{d}/{s}.results.json'
+            if f.endswith(sample_suffix):
+                s = f.replace(sample_suffix,"")
+                samples[s] = f'{d}/{s}{sample_suffix}'
     
+    # add samples from file with list of sample files
     if args.samples:
         samples = {s:samples[s] for s in [l.strip() for l in open(args.samples)]}
+    
+    if len(samples) == 0:
+        logging.error(f"\nERROR: No samples found in the provided directories (samples are expected to have suffix {sample_suffix})")
+        exit(1)
+
 
     rows = []
     edges = set()


### PR DESCRIPTION
1. There were some references to pp.errorlog and pp.warninglog, but I couldn't find these functions in pathogen-profiler so I made them use logging.error instead

2. I replaced `sys.exit()` with `sys.exit(1)` to indicate the error more clearly

3. I changed some code in the `collate` module to raise a clear error if there are no results to process