### PR TITLE
Fix typos that were misclassifying synonymous variants as "Uncertain significance"

### DIFF
--- a/tbprofiler/rules.py
+++ b/tbprofiler/rules.py
@@ -160,8 +160,8 @@ class SetConfidence(ProfilePlugin):
             
             for drug in var.gene_associated_drugs:
                 if drug not in confidence:
-                    if var.type=='synonymous_mutation':
-                        confidence[drug] = 'Not Assoc W R - Interim'
+                    if var.type=='synonymous_variant':
+                        confidence[drug] = 'Not assoc w R - Interim'
                     else:
                         confidence[drug] = 'Uncertain significance'
                     ann = {


### PR DESCRIPTION
Fixes https://github.com/jodyphelan/TBProfiler/issues/477, see issue for details and context.